### PR TITLE
Fix double content-length header issue

### DIFF
--- a/golang/main.go
+++ b/golang/main.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"log"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/adam-0001/cclient"
@@ -69,10 +68,6 @@ func CreateRequest(urlC *C.char, headerC *C.char, cookiesC *C.char, bodyC *C.cha
 	}
 
 	CreateHeaders(req, header, method)
-
-	if method == "POST" || method == "FORM" {
-		req.Header.Set("content-length", strconv.Itoa(len(body)))
-	}
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
While using this library, I was running into errors with POST requests because the Content-Length header was being sent twice. Some servers will refuse to process the request as the headers are considered to be malformed.

In Go, this header is generated automatically in the [NewRequest ](https://github.com/golang/go/blob/fced03a5c6dd22dd486106e3dd116510c28c6e4a/src/net/http/request.go#L565-L574) method as long as a body is provided.

The extra code that was added to set the Content-Length is thus not needed and should be removed to avoid issues with POST requests.

Verifying with Burp Suite:
Before:
![previous](https://user-images.githubusercontent.com/251231/210260655-74359bc5-dedc-4f46-816e-c535d76f3839.jpg)

After:
![working](https://user-images.githubusercontent.com/251231/210260664-376be467-6c96-473a-8e57-4c2528b69909.jpg)
